### PR TITLE
Feature/retain contextmenu

### DIFF
--- a/WorldOfTheThreeKingdoms/GamePlugins/HelpPlugin/Help.cs
+++ b/WorldOfTheThreeKingdoms/GamePlugins/HelpPlugin/Help.cs
@@ -73,7 +73,8 @@ namespace HelpPlugin
         {
             if (this.RichText.CurrentPageIndex == (this.RichText.PageCount - 1))
             {
-                this.IsShowing = false;
+                // Diable cancelling help dialog when left click the mouse, in order to enhance the user experience
+                // this.IsShowing = false;
             }
             else
             {
@@ -187,23 +188,27 @@ namespace HelpPlugin
             set
             {
                 this.isShowing = value;
+                WorldOfTheThreeKingdoms.GameScreens.MainGameScreen gameScreen = Session.MainGame.mainGameScreen;
+
                 if (value)
                 {
-                    Session.MainGame.mainGameScreen.PushUndoneWork(new UndoneWorkItem(UndoneWorkKind.Dialog, UndoneWorkSubKind.None));
-                    Session.MainGame.mainGameScreen.OnMouseMove += new Screen.MouseMove(this.screen_OnMouseMove);
-                    Session.MainGame.mainGameScreen.OnMouseLeftDown += new Screen.MouseLeftDown(this.screen_OnMouseLeftDown);
-                    Session.MainGame.mainGameScreen.OnMouseRightUp += new Screen.MouseRightUp(this.screen_OnMouseRightUp);
+                    gameScreen.PushUndoneWork(new UndoneWorkItem(UndoneWorkKind.Dialog, UndoneWorkSubKind.None));
+                    gameScreen.OnMouseMove += new Screen.MouseMove(this.screen_OnMouseMove);
+                    gameScreen.OnMouseLeftDown += new Screen.MouseLeftDown(this.screen_OnMouseLeftDown);
+                    gameScreen.OnMouseRightUp += new Screen.MouseRightUp(this.screen_OnMouseRightUp);
                     this.RichText.SetGameObjectTextBranch(null, this.CurrentBranch);
                 }
                 else
                 {
-                    if (Session.MainGame.mainGameScreen.PopUndoneWork().Kind != UndoneWorkKind.Dialog)
+                    if (gameScreen.PopUndoneWork().Kind != UndoneWorkKind.Dialog)
                     {
                         throw new Exception("The UndoneWork is not a Help Dialog.");
                     }
-                    Session.MainGame.mainGameScreen.OnMouseMove -= new Screen.MouseMove(this.screen_OnMouseMove);
-                    Session.MainGame.mainGameScreen.OnMouseLeftDown -= new Screen.MouseLeftDown(this.screen_OnMouseLeftDown);
-                    Session.MainGame.mainGameScreen.OnMouseRightUp -= new Screen.MouseRightUp(this.screen_OnMouseRightUp);
+                    gameScreen.OnMouseMove -= new Screen.MouseMove(this.screen_OnMouseMove);
+                    gameScreen.OnMouseLeftDown -= new Screen.MouseLeftDown(this.screen_OnMouseLeftDown);
+                    gameScreen.OnMouseRightUp -= new Screen.MouseRightUp(this.screen_OnMouseRightUp);
+
+                    gameScreen.updateGameScreenByCurrentTarget();
                 }
             }
         }

--- a/WorldOfTheThreeKingdoms/GameScreens/MGSshubiao.cs
+++ b/WorldOfTheThreeKingdoms/GameScreens/MGSshubiao.cs
@@ -220,48 +220,9 @@ namespace WorldOfTheThreeKingdoms.GameScreens
             {
                 if (((Session.GlobalVariables.SkyEye || Session.Current.Scenario.NoCurrentPlayer) || Session.Current.Scenario.CurrentPlayer.IsPositionKnown(this.position)) && ((this.Plugins.ContextMenuPlugin != null) && (this.PeekUndoneWork().Kind == UndoneWorkKind.None)))
                 {
-                    if ((((this.CurrentArchitecture != null) && (this.CurrentTroop != null)) && (this.CurrentTroop.BelongedFaction == Session.Current.Scenario.CurrentPlayer)) && (this.CurrentArchitecture.BelongedFaction == Session.Current.Scenario.CurrentPlayer) && this.CurrentTroop.Operated == false)
-                    {
-                        if (!(this.Plugins.ContextMenuPlugin.IsShowing || !Session.Current.Scenario.CurrentPlayer.Controlling))
-                        {
-                            this.Plugins.ContextMenuPlugin.IsShowing = true;
-                            this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this);
-                            this.Plugins.ContextMenuPlugin.SetMenuKindByName("ArchitectureTroopLeftClick");
-                            this.Plugins.ContextMenuPlugin.Prepare(InputManager.PoX, InputManager.PoY, base.viewportSize);
-                            this.bianduiLiebiaoBiaoji = "ArchitectureTroopLeftClick";
-                        }
-                    }
-                    else if ((this.CurrentTroop != null) && (this.CurrentTroop.BelongedFaction == Session.Current.Scenario.CurrentPlayer) && this.CurrentTroop.Operated == false)
-                    {
-                        if (!this.Plugins.ContextMenuPlugin.IsShowing && Session.Current.Scenario.IsPlayerControlling())
-                        {
-                            this.Plugins.ContextMenuPlugin.IsShowing = true;
-                            this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this.CurrentTroop);
-                            this.Plugins.ContextMenuPlugin.SetMenuKindByName("TroopLeftClick");
-                            this.Plugins.ContextMenuPlugin.Prepare(InputManager.PoX, InputManager.PoY, base.viewportSize);
-                            this.bianduiLiebiaoBiaoji = "TroopLeftClick";
-                            if (!this.Plugins.ContextMenuPlugin.IsShowing && (this.CurrentTroop.CutRoutewayDays > 0))
-                            {
-                                this.CurrentTroop.Leader.TextDestinationString = this.CurrentTroop.CutRoutewayDays.ToString();
-                                this.Plugins.tupianwenziPlugin.SetConfirmationDialog(this.Plugins.ConfirmationDialogPlugin, new GameDelegates.VoidFunction(this.CurrentTroop.StopCutRouteway), null);
-                                this.Plugins.ConfirmationDialogPlugin.SetPosition(ShowPosition.Center);
-                                this.Plugins.tupianwenziPlugin.SetGameObjectBranch(this.CurrentTroop.Leader, this.CurrentTroop.Leader, TextMessageKind.StopCutRouteway, "StopCutRouteway");
-                                this.Plugins.tupianwenziPlugin.IsShowing = true;
-                            }
-                        }
-                    }
-                    else if (((this.CurrentArchitecture != null) && (this.CurrentArchitecture.BelongedFaction == Session.Current.Scenario.CurrentPlayer)) && !(this.Plugins.ContextMenuPlugin.IsShowing || !Session.Current.Scenario.IsPlayerControlling()))
-                    {
-                        this.Plugins.ContextMenuPlugin.IsShowing = true;
-                        this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this.CurrentArchitecture);
-                        this.Plugins.ContextMenuPlugin.SetMenuKindByName("ArchitectureLeftClick");
-                        this.Plugins.ContextMenuPlugin.Prepare(InputManager.PoX, InputManager.PoY, base.viewportSize);
-
-                        this.bianduiLiebiaoBiaoji = "ArchitectureLeftClick";
-                        this.ShowBianduiLiebiao(UndoneWorkKind.None, FrameKind.Military, FrameFunction.Browse, false, true, false, true,
-                            this.CurrentArchitecture.Militaries, this.CurrentArchitecture.ZhengzaiBuchongDeBiandui(), "", "", this.CurrentArchitecture.MilitaryPopulation);
-                        this.ShowArchitectureSurveyPlugin(this.CurrentArchitecture);
-                    }
+                    // Assign the current mouse position so that selectorStartPosition can cache the selected target's accurate coordinates
+                    this.SelectorStartPosition = base.MousePosition;
+                    this.updateGameScreenByCurrentTarget();
                 }
             }
         }

--- a/WorldOfTheThreeKingdoms/GameScreens/MGSshubiao.cs
+++ b/WorldOfTheThreeKingdoms/GameScreens/MGSshubiao.cs
@@ -218,50 +218,11 @@ namespace WorldOfTheThreeKingdoms.GameScreens
             //if ((this.previousMouseState.LeftButton == ButtonState.Pressed) && (InputManager.NowMouse.LeftButton == ButtonState.Released) && (this.viewMove == ViewMove.Stop))
             if (InputManager.IsDownPre && InputManager.IsReleased && this.viewMove == ViewMove.Stop)
             {
+                // Assign the current mouse position so that selectorStartPosition can cache the selected target's accurate coordinates
+                this.SelectorStartPosition = base.MousePosition;
                 if (((Session.GlobalVariables.SkyEye || Session.Current.Scenario.NoCurrentPlayer) || Session.Current.Scenario.CurrentPlayer.IsPositionKnown(this.position)) && ((this.Plugins.ContextMenuPlugin != null) && (this.PeekUndoneWork().Kind == UndoneWorkKind.None)))
                 {
-                    if ((((this.CurrentArchitecture != null) && (this.CurrentTroop != null)) && (this.CurrentTroop.BelongedFaction == Session.Current.Scenario.CurrentPlayer)) && (this.CurrentArchitecture.BelongedFaction == Session.Current.Scenario.CurrentPlayer) && this.CurrentTroop.Operated == false)
-                    {
-                        if (!(this.Plugins.ContextMenuPlugin.IsShowing || !Session.Current.Scenario.CurrentPlayer.Controlling))
-                        {
-                            this.Plugins.ContextMenuPlugin.IsShowing = true;
-                            this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this);
-                            this.Plugins.ContextMenuPlugin.SetMenuKindByName("ArchitectureTroopLeftClick");
-                            this.Plugins.ContextMenuPlugin.Prepare(InputManager.PoX, InputManager.PoY, base.viewportSize);
-                            this.bianduiLiebiaoBiaoji = "ArchitectureTroopLeftClick";
-                        }
-                    }
-                    else if ((this.CurrentTroop != null) && (this.CurrentTroop.BelongedFaction == Session.Current.Scenario.CurrentPlayer) && this.CurrentTroop.Operated == false)
-                    {
-                        if (!this.Plugins.ContextMenuPlugin.IsShowing && Session.Current.Scenario.IsPlayerControlling())
-                        {
-                            this.Plugins.ContextMenuPlugin.IsShowing = true;
-                            this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this.CurrentTroop);
-                            this.Plugins.ContextMenuPlugin.SetMenuKindByName("TroopLeftClick");
-                            this.Plugins.ContextMenuPlugin.Prepare(InputManager.PoX, InputManager.PoY, base.viewportSize);
-                            this.bianduiLiebiaoBiaoji = "TroopLeftClick";
-                            if (!this.Plugins.ContextMenuPlugin.IsShowing && (this.CurrentTroop.CutRoutewayDays > 0))
-                            {
-                                this.CurrentTroop.Leader.TextDestinationString = this.CurrentTroop.CutRoutewayDays.ToString();
-                                this.Plugins.tupianwenziPlugin.SetConfirmationDialog(this.Plugins.ConfirmationDialogPlugin, new GameDelegates.VoidFunction(this.CurrentTroop.StopCutRouteway), null);
-                                this.Plugins.ConfirmationDialogPlugin.SetPosition(ShowPosition.Center);
-                                this.Plugins.tupianwenziPlugin.SetGameObjectBranch(this.CurrentTroop.Leader, this.CurrentTroop.Leader, TextMessageKind.StopCutRouteway, "StopCutRouteway");
-                                this.Plugins.tupianwenziPlugin.IsShowing = true;
-                            }
-                        }
-                    }
-                    else if (((this.CurrentArchitecture != null) && (this.CurrentArchitecture.BelongedFaction == Session.Current.Scenario.CurrentPlayer)) && !(this.Plugins.ContextMenuPlugin.IsShowing || !Session.Current.Scenario.IsPlayerControlling()))
-                    {
-                        this.Plugins.ContextMenuPlugin.IsShowing = true;
-                        this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this.CurrentArchitecture);
-                        this.Plugins.ContextMenuPlugin.SetMenuKindByName("ArchitectureLeftClick");
-                        this.Plugins.ContextMenuPlugin.Prepare(InputManager.PoX, InputManager.PoY, base.viewportSize);
-
-                        this.bianduiLiebiaoBiaoji = "ArchitectureLeftClick";
-                        this.ShowBianduiLiebiao(UndoneWorkKind.None, FrameKind.Military, FrameFunction.Browse, false, true, false, true,
-                            this.CurrentArchitecture.Militaries, this.CurrentArchitecture.ZhengzaiBuchongDeBiandui(), "", "", this.CurrentArchitecture.MilitaryPopulation);
-                        this.ShowArchitectureSurveyPlugin(this.CurrentArchitecture);
-                    }
+                    this.updateGameScreenByCurrentTarget();
                 }
             }
         }

--- a/WorldOfTheThreeKingdoms/GameScreens/MainGameScreen.cs
+++ b/WorldOfTheThreeKingdoms/GameScreens/MainGameScreen.cs
@@ -3596,5 +3596,50 @@ namespace WorldOfTheThreeKingdoms.GameScreens
                 return Session.GlobalVariables.SkyEyeSimpleNotification;
             }
         }
+        public void updateGameScreenByCurrentTarget()
+        {            
+            if ((((this.CurrentArchitecture != null) && (this.CurrentTroop != null)) && (this.CurrentTroop.BelongedFaction == Session.Current.Scenario.CurrentPlayer)) && (this.CurrentArchitecture.BelongedFaction == Session.Current.Scenario.CurrentPlayer) && this.CurrentTroop.Operated == false)
+            {
+                if (!(this.Plugins.ContextMenuPlugin.IsShowing || !Session.Current.Scenario.CurrentPlayer.Controlling))
+                {
+                    this.Plugins.ContextMenuPlugin.IsShowing = true;
+                    this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this);
+                    this.Plugins.ContextMenuPlugin.SetMenuKindByName("ArchitectureTroopLeftClick");
+                    this.Plugins.ContextMenuPlugin.Prepare(this.SelectorStartPosition.X, this.SelectorStartPosition.Y, base.viewportSize);
+                    this.bianduiLiebiaoBiaoji = "ArchitectureTroopLeftClick";
+                }
+            }
+            else if ((this.CurrentTroop != null) && (this.CurrentTroop.BelongedFaction == Session.Current.Scenario.CurrentPlayer) && this.CurrentTroop.Operated == false)
+            {
+                if (!this.Plugins.ContextMenuPlugin.IsShowing && Session.Current.Scenario.IsPlayerControlling())
+                {
+                    this.Plugins.ContextMenuPlugin.IsShowing = true;
+                    this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this.CurrentTroop);
+                    this.Plugins.ContextMenuPlugin.SetMenuKindByName("TroopLeftClick");
+                    this.Plugins.ContextMenuPlugin.Prepare(this.SelectorStartPosition.X, this.SelectorStartPosition.Y, base.viewportSize);
+                    this.bianduiLiebiaoBiaoji = "TroopLeftClick";
+                    if (!this.Plugins.ContextMenuPlugin.IsShowing && (this.CurrentTroop.CutRoutewayDays > 0))
+                    {
+                        this.CurrentTroop.Leader.TextDestinationString = this.CurrentTroop.CutRoutewayDays.ToString();
+                        this.Plugins.tupianwenziPlugin.SetConfirmationDialog(this.Plugins.ConfirmationDialogPlugin, new GameDelegates.VoidFunction(this.CurrentTroop.StopCutRouteway), null);
+                        this.Plugins.ConfirmationDialogPlugin.SetPosition(ShowPosition.Center);
+                        this.Plugins.tupianwenziPlugin.SetGameObjectBranch(this.CurrentTroop.Leader, this.CurrentTroop.Leader, TextMessageKind.StopCutRouteway, "StopCutRouteway");
+                        this.Plugins.tupianwenziPlugin.IsShowing = true;
+                    }
+                }
+            }
+            else if (((this.CurrentArchitecture != null) && (this.CurrentArchitecture.BelongedFaction == Session.Current.Scenario.CurrentPlayer)) && !(this.Plugins.ContextMenuPlugin.IsShowing || !Session.Current.Scenario.IsPlayerControlling()))
+            {
+                this.Plugins.ContextMenuPlugin.IsShowing = true;
+                this.Plugins.ContextMenuPlugin.SetCurrentGameObject(this.CurrentArchitecture);
+                this.Plugins.ContextMenuPlugin.SetMenuKindByName("ArchitectureLeftClick");
+                this.Plugins.ContextMenuPlugin.Prepare(this.SelectorStartPosition.X, this.SelectorStartPosition.Y, base.viewportSize);
+
+                this.bianduiLiebiaoBiaoji = "ArchitectureLeftClick";
+                this.ShowBianduiLiebiao(UndoneWorkKind.None, FrameKind.Military, FrameFunction.Browse, false, true, false, true,
+                    this.CurrentArchitecture.Militaries, this.CurrentArchitecture.ZhengzaiBuchongDeBiandui(), "", "", this.CurrentArchitecture.MilitaryPopulation);
+                this.ShowArchitectureSurveyPlugin(this.CurrentArchitecture);
+            }
+        }
     }
 }


### PR DESCRIPTION
改善体验：原本在点击执行项目的问号提示后 再按左/右键，提示框和执行菜单会一起消失， 玩家不得不再点开城市或者军队。 修改了当前逻辑，左键不能取消提示框，点击右键时只有提示框消失，执行菜单仍然处于打开状态。