### PR TITLE
Fix background music on Windows

### DIFF
--- a/ZHSan/ZHSan.Core/Platforms/PlatformBase.cs
+++ b/ZHSan/ZHSan.Core/Platforms/PlatformBase.cs
@@ -451,9 +451,22 @@ namespace Platforms
                 foreach (var item in songs)
                 {
                     res = item;
-                    if ((!item.EndsWith(".mp3") && !item.EndsWith(".wav")))
+                    // Issue: ArgumentException - Could not load the specified container!
+                    // Solution: Use OGG audio files instead of MP3 (tested on Windows 11).
+                    // Ref. https://cloud.tencent.com/developer/ask/sof/106178561?from=16139
+                    if (OperatingSystem.IsWindows()) // Alternative: Platform.PlatFormType == PlatFormType.Win if available
                     {
-                        continue;
+                        if (!item.EndsWith(".ogg"))
+                        {
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        if (!item.EndsWith(".mp3") && !item.EndsWith(".wav"))
+                        {
+                            continue;
+                        }
                     }
                     if (Platform.PlatFormType == PlatFormType.Android)
                     {

--- a/ZHSan/ZHSan.Core/Platforms/PlatformBase.cs
+++ b/ZHSan/ZHSan.Core/Platforms/PlatformBase.cs
@@ -454,19 +454,9 @@ namespace Platforms
                     // Issue: ArgumentException - Could not load the specified container!
                     // Solution: Use OGG audio files instead of MP3 (tested on Windows 11).
                     // Ref. https://cloud.tencent.com/developer/ask/sof/106178561?from=16139
-                    if (OperatingSystem.IsWindows()) // Alternative: Platform.PlatFormType == PlatFormType.Win if available
+                    if (!item.EndsWith(".mp3") && !item.EndsWith(".wav") && !item.EndsWith(".ogg"))
                     {
-                        if (!item.EndsWith(".ogg"))
-                        {
-                            continue;
-                        }
-                    }
-                    else
-                    {
-                        if (!item.EndsWith(".mp3") && !item.EndsWith(".wav"))
-                        {
-                            continue;
-                        }
+                        continue;
                     }
                     if (Platform.PlatFormType == PlatFormType.Android)
                     {
@@ -475,9 +465,16 @@ namespace Platforms
                             res = res.Substring(res.LastIndexOf('\\') + 1);
                         }
                     }
-                    songs2.Add(res);
-                    Song song3 = Song.FromUri(res, new Uri(res, UriKind.Relative));
-                    songslist.Add(song3);
+                    try
+                    {
+                        Song song3 = Song.FromUri(res, new Uri(res, UriKind.Relative));
+                        songs2.Add(res);
+                        songslist.Add(song3);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Skip any invalid songs
+                    }
                 }
                 if (songslist.Count >= 1)
                 {

--- a/ZHSan/ZHSan.Core/Platforms/PlatformDesktop.cs
+++ b/ZHSan/ZHSan.Core/Platforms/PlatformDesktop.cs
@@ -1270,6 +1270,17 @@ namespace Platforms
             }
         }
 
+        public override string[] GetFilesBasic(string dir, bool all = false)
+        {
+            try
+            {
+                return Directory.GetFiles(dir);
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 
     public class PlatformTask


### PR DESCRIPTION
The game is missing background music when running on a local Windows computer.

Changes:
- Implement GetFilesBasic() in PlatformDesktop.cs
- Use OGG audio files instead of MP3 on Windows 11
