### PR TITLE
Fix window close button on Windows

### DIFF
--- a/ZHSan/ZHSan.Core/MainGame.cs
+++ b/ZHSan/ZHSan.Core/MainGame.cs
@@ -174,7 +174,7 @@ namespace WorldOfTheThreeKingdoms
             if (Platform.PlatFormType == PlatFormType.Win || Platform.PlatFormType == PlatFormType.Desktop)
             {
                 Platform.Current.SetWindowAllowUserResizing(true);
-                
+                this.Exiting += this.Close_Game; // DesktopGL/MonoGame issue: Crash on window close (X) button - Windows 11
             }
 
             //try
@@ -210,6 +210,11 @@ namespace WorldOfTheThreeKingdoms
             {
                 mainGameScreen.Window_ClientSizeChanged(sender, e);
             }
+        }
+        
+        private void Close_Game(object sender, EventArgs e)
+        {
+            Environment.Exit(0);
         }
 
         /// <summary>


### PR DESCRIPTION
The game crashes on Windows when clicking the X button to close it.

Fix:

- Add event hook to this.Exiting method for game closing
- Tested: behavior matches Steam version

Reminder: Haven't merged the branch (fix-win-music-20260619) from last time yet. 